### PR TITLE
Added compatibility with links containing alternate display text.

### DIFF
--- a/action.php
+++ b/action.php
@@ -24,7 +24,8 @@ class action_plugin_mredirect extends DokuWiki_Action_Plugin {
               $url = $inner;    # link is URL already
           } else {
               msg (sprintf ('From: <a href="'.wl($ID,'do=edit').'">'.hsc($ID).'</a>'));
-              $url = html_wikilink ($inner, $name=null, $search='');
+              $parts = explode('|', $inner);
+              $url = html_wikilink ($parts[0], $name=null, $search='');
               $url = substr ($url, strpos ($url, '"') + 1);
               $url = substr ($url, 0, strpos ($url, '"'));
           }


### PR DESCRIPTION
Currently, if you have a link like `[[new_page|This page has moved; please click here.]]` the plugin will create an invalid link because it includes the display text as part of the URL. This PR fixes that problem.
