### PR TITLE
Remove deprecated require_once.

### DIFF
--- a/action.php
+++ b/action.php
@@ -2,7 +2,6 @@
 
 if(!defined('DOKU_INC')) die();
 if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
-require_once(DOKU_PLUGIN.'action.php');
 
 class action_plugin_mredirect extends DokuWiki_Action_Plugin {
 


### PR DESCRIPTION
The require_once in this file causes deprecation warnings; removing it does not appear to prevent proper functioning of the plugin, as auto-loading seems to be working as expected.